### PR TITLE
Change false to empty string to prevent error on line 41 of mailman gem ...

### DIFF
--- a/lib/mailman-rails.rb
+++ b/lib/mailman-rails.rb
@@ -37,8 +37,8 @@ module Mailman
     def self.run!
 
       # Under no circumstances should Mailman itself load the Rails enviroment!
-      Mailman.config.rails_root = false
-
+      Mailman.config.rails_root = ''
+      
       self.application.run
     end
 


### PR DESCRIPTION
Get Gem.  Big help.  I did however have a problem and I was hoping you could merge in this fix.  The use of false in this case is causing an error for me with the mailman gem.  The error occurred line 41 of application.rb file in the instance method "run" of Mailman::Application class.

I believe that if you use an empty string you will still prevent mailman from loading the Rails environment and at the same time prevent this this error.

Here is the console output for the error I was getting before the fix:

$ env RAILS_ENV=development bundle exec rake mailman --trace

/Users/andrewg/.rvm/gems/ruby-1.9.3-p194/gems/mailman-rails-0.0.3/lib/mailman-rails/tasks/mailman.rake
*\* Invoke mailman (first_time)
*\* Invoke environment (first_time)
*\* Execute environment
*\* Execute mailman
rake aborted!
can't convert false into String
/Users/andrewg/.rvm/gems/ruby-1.9.3-p194/gems/mailman-0.5.3/lib/mailman/application.rb:41:in `join'
/Users/andrewg/.rvm/gems/ruby-1.9.3-p194/gems/mailman-0.5.3/lib/mailman/application.rb:41:in`run'
...........

Thanks.

Andrew
