### PR TITLE
Added require 'daemons' to the rake file..

### DIFF
--- a/lib/mailman-rails/tasks/mailman.rake
+++ b/lib/mailman-rails/tasks/mailman.rake
@@ -1,4 +1,5 @@
 require File.expand_path('../../../mailman-rails', __FILE__)
+require 'daemons'
 
 
 namespace :mailman do


### PR DESCRIPTION
i couldn't get the mailman.start and other rake commands to work on my machine without explicitly requiring it in the rake file. i would imagine that i am not the only one, and i don't see that it would hurt if someone didn't need it, so i added it.

let me know if you see any problems with this..

thanks!
